### PR TITLE
Use QueryRenderer defaults

### DIFF
--- a/src/QueryRenderer.js
+++ b/src/QueryRenderer.js
@@ -13,26 +13,13 @@ type Props = {|
 |};
 
 export default class QueryRenderer extends React.Component<Props> {
-  renderInner = ({ error, props }: Object) => {
-    if (error) {
-      console.warn(error); // eslint-disable-line no-console
-      return <div>Query failed </div>;
-    }
-
-    if (props) {
-      return this.props.render(props);
-    }
-
-    return <div>loading...</div>;
-  };
-
   render() {
     return (
       <OriginalQueryRenderer
         environment={environment}
         query={this.props.query}
         variables={this.props.variables}
-        render={this.renderInner}
+        onResponse={this.props.render}
       />
     );
   }


### PR DESCRIPTION
It's good to have this custom wrapper but it's better to use the defaults. The default implementation is better than this one (check the source code) so it's a good idea to use it unless you really need something very specific which is not this case.